### PR TITLE
Remove unused function newPodForCR()

### DIFF
--- a/pkg/controller/fileintegrity/fileintegrity_controller.go
+++ b/pkg/controller/fileintegrity/fileintegrity_controller.go
@@ -236,29 +236,6 @@ func defaultAIDEScript() *corev1.ConfigMap {
 	}
 }
 
-// newPodForCR returns a busybox pod with the same name/namespace as the cr
-func newPodForCR(cr *fileintegrityv1alpha1.FileIntegrity) *corev1.Pod {
-	labels := map[string]string{
-		"app": cr.Name,
-	}
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Name + "-pod",
-			Namespace: cr.Namespace,
-			Labels:    labels,
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:    "busybox",
-					Image:   "busybox",
-					Command: []string{"sleep", "3600"},
-				},
-			},
-		},
-	}
-}
-
 func workerAideDaemonset() *appsv1.DaemonSet {
 	priv := true
 	runAs := int64(0)


### PR DESCRIPTION
It wasn't clear to me if you keep the function around to be able to add a
pod for debugging easily or if it's just a leftover.

If it's just a leftover, it can probably go, otherwise it would be nice to
add a comment instead.