### PR TITLE
More configuration updates

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -1,12 +1,16 @@
 package common
 
 const (
-	FileIntegrityNamespace     = "openshift-file-integrity"
-	DefaultConfDataKey         = "aide.conf"
-	DefaultConfigMapName       = "aide-conf"
-	WorkerDaemonSetName        = "aide-worker"
-	MasterDaemonSetName        = "aide-master"
-	AideScriptConfigMapName    = "aide-script"
-	OperatorServiceAccountName = "file-integrity-operator"
-	AideScriptPath             = "/scripts/aide.sh"
+	FileIntegrityNamespace        = "openshift-file-integrity"
+	DefaultConfDataKey            = "aide.conf"
+	DefaultConfigMapName          = "aide-conf"
+	WorkerDaemonSetName           = "aide-worker"
+	MasterDaemonSetName           = "aide-master"
+	WorkerReinitDaemonSetName     = "aide-reinit-worker"
+	MasterReinitDaemonSetName     = "aide-reinit-master"
+	AideScriptConfigMapName       = "aide-script"
+	AideInitScriptConfigMapName   = "aide-init"
+	AideReinitScriptConfigMapName = "aide-reinit"
+	OperatorServiceAccountName    = "file-integrity-operator"
+	AideScriptPath                = "/scripts/aide.sh"
 )

--- a/pkg/controller/fileintegrity/config_defaults.go
+++ b/pkg/controller/fileintegrity/config_defaults.go
@@ -1,5 +1,19 @@
 package fileintegrity
 
+var aideInitContainerScript = `#!/bin/sh
+    if test -f /hostroot/etc/kubernetes/aide.reinit; then
+      echo "reinitializing AIDE db"
+      mv /hostroot/etc/kubernetes/aide.db.gz /hostroot/etc/kubernetes/aide.db.gz.backup-$(date +%s)
+      mv /hostroot/etc/kubernetes/aide.log /hostroot/etc/kubernetes/aide.log.backup-$(date +%s)
+      aide -c /tmp/aide.conf -i
+      rm -f /hostroot/etc/kubernetes/aide.reinit
+    fi
+`
+
+var aideReinitContainerScript = `#!/bin/sh
+    touch /hostroot/etc/kubernetes/aide.reinit
+`
+
 var aideScript = `#!/bin/sh
     if test ! -f /hostroot/etc/kubernetes/aide.db.gz; then
       echo "initializing AIDE db"


### PR DESCRIPTION
- Add AIDE db reinit process upon user-provided config update.
- Update README.md (configuration and TODO sections).
- Refactor initial creation of configMap resources.
- Convert the user-provided config before comparing to the active config to
  avoid continually updating.
@jhrozek @JAORMX