### PR TITLE
update default AIDE config

### DIFF
--- a/pkg/controller/fileintegrity/config_defaults.go
+++ b/pkg/controller/fileintegrity/config_defaults.go
@@ -28,110 +28,176 @@ var aideScript = `#!/bin/sh
     exit 1`
 
 var defaultAideConfig = `@@define DBDIR /hostroot/etc/kubernetes
-    @@define LOGDIR /hostroot/etc/kubernetes
-    database=file:@@{DBDIR}/aide.db.gz
-    database_out=file:@@{DBDIR}/aide.db.gz
-    gzip_dbout=yes
-    verbose=10
-    report_url=file:@@{LOGDIR}/aide.log
-    report_url=stdout
-    # These are the default rules.
-    FIPSR = p+i+n+u+g+s+m+c+acl+selinux+xattrs+sha256
-    ALLXTRAHASHES = sha1+rmd160+sha256+sha512+tiger
-    EVERYTHING = R+ALLXTRAHASHES
-    NORMAL = FIPSR+sha512
-    DIR = p+i+n+u+g+acl+selinux+xattrs
-    PERMS = p+i+u+g+acl+selinux
-    LOG = >
-    LSPP = FIPSR+sha512
-    DATAONLY =  p+n+u+g+s+acl+selinux+xattrs+sha256
-    /hostroot/boot   NORMAL
-    /hostroot/bin    NORMAL
-    /hostroot/sbin   NORMAL
-    /hostroot/lib    NORMAL
-    /hostroot/lib64  NORMAL
-    /hostroot/opt    NORMAL
-    /hostroot/usr    NORMAL
-    /hostroot/root   NORMAL
-    !/hostroot/usr/src
-    !/hostroot/usr/tmp
-    /hostroot/etc    PERMS
-    !/hostroot/etc/mtab
-    !/hostroot/etc/.*~
-    /hostroot/etc/exports  NORMAL
-    /hostroot/etc/fstab    NORMAL
-    /hostroot/etc/passwd   NORMAL
-    /hostroot/etc/group    NORMAL
-    /hostroot/etc/gshadow  NORMAL
-    /hostroot/etc/shadow   NORMAL
-    /hostroot/etc/security/opasswd   NORMAL
-    /hostroot/etc/hosts.allow   NORMAL
-    /hostroot/etc/hosts.deny    NORMAL
-    /hostroot/etc/sudoers NORMAL
-    /hostroot/etc/skel NORMAL
-    /hostroot/etc/logrotate.d NORMAL
-    /hostroot/etc/resolv.conf DATAONLY
-    /hostroot/etc/nscd.conf NORMAL
-    /hostroot/etc/securetty NORMAL
-    /hostroot/etc/profile NORMAL
-    /hostroot/etc/bashrc NORMAL
-    /hostroot/etc/bash_completion.d/ NORMAL
-    /hostroot/etc/login.defs NORMAL
-    /hostroot/etc/zprofile NORMAL
-    /hostroot/etc/zshrc NORMAL
-    /hostroot/etc/zlogin NORMAL
-    /hostroot/etc/zlogout NORMAL
-    /hostroot/etc/profile.d/ NORMAL
-    /hostroot/etc/X11/ NORMAL
-    /hostroot/etc/yum.conf NORMAL
-    /hostroot/etc/yumex.conf NORMAL
-    /hostroot/etc/yumex.profiles.conf NORMAL
-    /hostroot/etc/yum/ NORMAL
-    /hostroot/etc/yum.repos.d/ NORMAL
-    /hostroot/var/log   LOG
-    /hostroot/var/run/utmp LOG
-    !/hostroot/var/log/sa
-    !/hostroot/var/log/pods
-    !/hostroot/var/log/aide.log
-    /hostroot/etc/audit/ LSPP
-    /hostroot/etc/libaudit.conf LSPP
-    /hostroot/usr/sbin/stunnel LSPP
-    /hostroot/var/spool/at LSPP
-    /hostroot/etc/at.allow LSPP
-    /hostroot/etc/at.deny LSPP
-    /hostroot/etc/cron.allow LSPP
-    /hostroot/etc/cron.deny LSPP
-    /hostroot/etc/cron.d/ LSPP
-    /hostroot/etc/cron.daily/ LSPP
-    /hostroot/etc/cron.hourly/ LSPP
-    /hostroot/etc/cron.monthly/ LSPP
-    /hostroot/etc/cron.weekly/ LSPP
-    /hostroot/etc/crontab LSPP
-    /hostroot/var/spool/cron/root LSPP
-    /hostroot/etc/login.defs LSPP
-    /hostroot/etc/securetty LSPP
-    /hostroot/var/log/faillog LSPP
-    /hostroot/var/log/lastlog LSPP
-    /hostroot/etc/hosts LSPP
-    /hostroot/etc/sysconfig LSPP
-    /hostroot/etc/inittab LSPP
-    /hostroot/etc/grub/ LSPP
-    /hostroot/etc/rc.d LSPP
-    /hostroot/etc/ld.so.conf LSPP
-    /hostroot/etc/localtime LSPP
-    /hostroot/etc/sysctl.conf LSPP
-    /hostroot/etc/modprobe.conf LSPP
-    /hostroot/etc/pam.d LSPP
-    /hostroot/etc/security LSPP
-    /hostroot/etc/aliases LSPP
-    /hostroot/etc/postfix LSPP
-    /hostroot/etc/ssh/sshd_config LSPP
-    /hostroot/etc/ssh/ssh_config LSPP
-    /hostroot/etc/stunnel LSPP
-    /hostroot/etc/vsftpd.ftpusers LSPP
-    /hostroot/etc/vsftpd LSPP
-    /hostroot/etc/issue LSPP
-    /hostroot/etc/issue.net LSPP
-    /hostroot/etc/cups LSPP
-    !/hostroot/var/log/and-httpd
-    /hostroot/root/\..* PERMS`
+@@define LOGDIR /hostroot/etc/kubernetes
+database=file:@@{DBDIR}/aide.db.gz
+database_out=file:@@{DBDIR}/aide.db.gz
+gzip_dbout=yes
+verbose=5
+report_url=file:@@{LOGDIR}/aide.log
+report_url=stdout
+ALLXTRAHASHES = sha1+rmd160+sha256+sha512+tiger
+EVERYTHING = R+ALLXTRAHASHES
+NORMAL = p+i+n+u+g+s+m+c+acl+selinux+xattrs+sha512
+DIR = p+i+n+u+g+acl+selinux+xattrs
+PERMS = p+u+g+acl+selinux+xattrs
+LOG = p+u+g+n+S+acl+selinux+xattrs
+CONTENT = sha512+ftype
+CONTENT_EX = sha512+ftype+p+u+g+n+acl+selinux+xattrs
+DATAONLY =  p+n+u+g+s+acl+selinux+xattrs+sha512
+
+/hostroot/boot/        CONTENT_EX
+/hostroot/opt/        CONTENT
+/hostroot/root/\..* PERMS
+/hostroot/root/   CONTENT_EX
+!/hostroot/usr/src/
+!/hostroot/usr/tmp/
+
+/hostroot/usr/    CONTENT_EX
+
+# trusted databases
+/hostroot/etc/hosts$      CONTENT_EX
+/hostroot/etc/host.conf$  CONTENT_EX
+/hostroot/etc/hostname$   CONTENT_EX
+/hostroot/etc/issue$      CONTENT_EX
+/hostroot/etc/issue.net$  CONTENT_EX
+/hostroot/etc/protocols$  CONTENT_EX
+/hostroot/etc/services$   CONTENT_EX
+/hostroot/etc/localtime$  CONTENT_EX
+/hostroot/etc/alternatives/ CONTENT_EX
+/hostroot/etc/sysconfig   CONTENT_EX
+/hostroot/etc/mime.types$ CONTENT_EX
+/hostroot/etc/terminfo/   CONTENT_EX
+/hostroot/etc/exports$    CONTENT_EX
+/hostroot/etc/fstab$      CONTENT_EX
+/hostroot/etc/passwd$     CONTENT_EX
+/hostroot/etc/group$      CONTENT_EX
+/hostroot/etc/gshadow$    CONTENT_EX
+/hostroot/etc/shadow$     CONTENT_EX
+/hostroot/etc/subgid$     CONTENT_EX
+/hostroot/etc/subuid$     CONTENT_EX
+/hostroot/etc/security/opasswd$ CONTENT_EX
+/hostroot/etc/skel/       CONTENT_EX
+/hostroot/etc/subuid$     CONTENT_EX
+/hostroot/etc/subgid$     CONTENT_EX
+/hostroot/etc/sssd/       CONTENT_EX
+/hostroot/etc/machine-id$ CONTENT_EX
+/hostroot/etc/system-release-cpe$ CONTENT_EX
+/hostroot/etc/shells$     CONTENT_EX
+/hostroot/etc/tmux.conf$  CONTENT_EX
+/hostroot/etc/xattr.conf$ CONTENT_EX
+
+# networking
+/hostroot/etc/hosts.allow$   CONTENT_EX
+/hostroot/etc/hosts.deny$    CONTENT_EX
+!/hostroot/etc/NetworkManager/system-connections/
+/hostroot/etc/NetworkManager/ CONTENT_EX
+/hostroot/etc/networks$ CONTENT_EX
+/hostroot/etc/dhcp/ CONTENT_EX
+/hostroot/etc/resolv.conf$ DATAONLY
+/hostroot/etc/nscd.conf$ CONTENT_EX
+
+# logins and accounts
+/hostroot/etc/login.defs$ CONTENT_EX
+/hostroot/etc/libuser.conf$ CONTENT_EX
+/hostroot/etc/pam.d/ CONTENT_EX
+/hostroot/etc/security/ CONTENT_EX
+/hostroot/etc/securetty$ CONTENT_EX
+/hostroot/etc/polkit-1/ CONTENT_EX
+/hostroot/etc/sudo.conf$ CONTENT_EX
+/hostroot/etc/sudoers CONTENT_EX
+/hostroot/etc/sudoers.d/ CONTENT_EX
+
+# Shell/X startup files
+/hostroot/etc/profile$ CONTENT_EX
+/hostroot/etc/profile.d/ CONTENT_EX
+/hostroot/etc/bashrc$ CONTENT_EX
+/hostroot/etc/bash_completion.d/ CONTENT_EX
+/hostroot/etc/zprofile$ CONTENT_EX
+/hostroot/etc/zshrc$ CONTENT_EX
+/hostroot/etc/zlogin$ CONTENT_EX
+/hostroot/etc/zlogout$ CONTENT_EX
+
+# Pkg manager
+/hostroot/etc/dnf/ CONTENT_EX
+/hostroot/etc/yum.conf$ CONTENT_EX
+
+# auditing
+# AIDE produces an audit record, so this becomes perpetual motion.
+/hostroot/etc/audit/ CONTENT_EX
+/hostroot/etc/libaudit.conf$ CONTENT_EX
+/hostroot/etc/aide.conf$  CONTENT_EX
+
+# System logs
+/hostroot/etc/rsyslog.conf$ CONTENT_EX
+/hostroot/etc/logrotate.conf$ CONTENT_EX
+/hostroot/etc/logrotate.d/ CONTENT_EX
+/hostroot/etc/systemd/journald.conf$ CONTENT_EX
+
+# secrets
+/hostroot/etc/pkcs11/ CONTENT_EX
+/hostroot/etc/pki/ CONTENT_EX
+/hostroot/etc/crypto-policies/ CONTENT_EX
+
+# init system
+/hostroot/etc/systemd/ CONTENT_EX
+/hostroot/etc/rc.d/ CONTENT_EX
+/hostroot/etc/tmpfiles.d/ CONTENT_EX
+
+# boot config
+/hostroot/etc/default/ CONTENT_EX
+/hostroot/etc/grub.d/ CONTENT_EX
+/hostroot/etc/dracut.conf CONTENT_EX
+/hostroot/etc/dracut.conf.d/ CONTENT_EX
+
+# glibc linker
+/hostroot/etc/ld.so.cache$ CONTENT_EX
+/hostroot/etc/ld.so.conf$ CONTENT_EX
+/hostroot/etc/ld.so.conf.d/ CONTENT_EX
+
+# kernel config
+/hostroot/etc/sysctl.conf CONTENT_EX
+/hostroot/etc/sysctl.d/ CONTENT_EX
+/hostroot/etc/modprobe.d/ CONTENT_EX
+/hostroot/etc/modules-load.d/ CONTENT_EX
+/hostroot/etc/depmod.d/ CONTENT_EX
+/hostroot/etc/udev/ CONTENT_EX
+/hostroot/etc/crypttab$ CONTENT_EX
+
+#### Daemons ####
+# time keeping
+/hostroot/etc/chrony.conf CONTENT_EX
+/hostroot/etc/chrony.keys$ CONTENT_EX
+
+# mail
+/hostroot/etc/aliases$ CONTENT_EX
+/hostroot/etc/aliases.db$ CONTENT_EX
+
+# ssh
+/hostroot/etc/ssh/sshd_config CONTENT_EX
+/hostroot/etc/ssh/ssh_config CONTENT_EX
+
+# xinetd
+/hostroot/etc/xinetd.conf$ CONTENT_EX
+/hostroot/etc/xinetd.d/ CONTENT_EX
+
+# Ignore some files
+!/hostroot/etc/mtab$
+!/hostroot/etc/.*~
+
+# Now everything else
+/hostroot/etc/    PERMS
+
+# With AIDE's default verbosity level of 5, these would give lots of
+# warnings upon tree traversal. It might change with future version.
+#
+#=/lost\+found    DIR
+#=/home           DIR
+
+# Admins dot files constantly change, just check perms
+/hostroot/root/\..* PERMS
+!/hostroot/root/.xauth*
+
+# OpenShift specific
+!/hostroot/var
+!/hostroot/etc/kubernetes/static-pod-resources
+!/hostroot/etc/kubernetes/aide.reinit`


### PR DESCRIPTION
This PR changes the default AIDE config to match the RHEL8 default, and excludes the following:
/var
/etc/kubernetes/static-pod-resource
/etc/kubernetes/aide.reinit