### PR TITLE
Move openapi schema and subresources to top level and switch to v1beta1

### DIFF
--- a/deploy/crds/file-integrity.openshift.io_fileintegrities_crd.yaml
+++ b/deploy/crds/file-integrity.openshift.io_fileintegrities_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: fileintegrities.file-integrity.openshift.io
@@ -10,49 +10,49 @@ spec:
     plural: fileintegrities
     singular: fileintegrity
   scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: FileIntegrity is the Schema for the fileintegrities API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: FileIntegritySpec defines the desired state of FileIntegrity
+          properties:
+            config:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "operator-sdk generate k8s" to regenerate code after
+                modifying this file Add custom validation using kubebuilder tags:
+                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              properties:
+                key:
+                  type: string
+                name:
+                  type: string
+                namespace:
+                  type: string
+              type: object
+          required:
+          - config
+          type: object
+        status:
+          description: FileIntegrityStatus defines the observed state of FileIntegrity
+          type: object
+      type: object
   version: v1alpha1
   versions:
   - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: FileIntegrity is the Schema for the fileintegrities API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: FileIntegritySpec defines the desired state of FileIntegrity
-            properties:
-              config:
-                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                  Important: Run "operator-sdk generate k8s" to regenerate code after
-                  modifying this file Add custom validation using kubebuilder tags:
-                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-                properties:
-                  key:
-                    type: string
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                type: object
-            required:
-            - config
-            type: object
-          status:
-            description: FileIntegrityStatus defines the observed state of FileIntegrity
-            type: object
-        type: object
     served: true
     storage: true
-    subresources:
-      status: {}


### PR DESCRIPTION
v1 is not applicable for 4.2 clusters; so let's stick with v1beta1 for now.