### PR TITLE
Update CRD to use v1

### DIFF
--- a/deploy/crds/file-integrity.openshift.io_fileintegrities_crd.yaml
+++ b/deploy/crds/file-integrity.openshift.io_fileintegrities_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: fileintegrities.file-integrity.openshift.io


### PR DESCRIPTION
we can already use v1 instead of v1beta1. So lets use that.