### PR TITLE
add back v1beta1 CRD for 4.2 clusters

### DIFF
--- a/deploy/crds/4.2/file-integrity.openshift.io_fileintegrities_crd.yaml
+++ b/deploy/crds/4.2/file-integrity.openshift.io_fileintegrities_crd.yaml
@@ -1,0 +1,58 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: fileintegrities.file-integrity.openshift.io
+spec:
+  group: file-integrity.openshift.io
+  names:
+    kind: FileIntegrity
+    listKind: FileIntegrityList
+    plural: fileintegrities
+    singular: fileintegrity
+  scope: Namespaced
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: FileIntegrity is the Schema for the fileintegrities API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: FileIntegritySpec defines the desired state of FileIntegrity
+            properties:
+              config:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                properties:
+                  key:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                type: object
+            required:
+            - config
+            type: object
+          status:
+            description: FileIntegrityStatus defines the observed state of FileIntegrity
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/crds/4.2/file-integrity.openshift.io_v1alpha1_fileintegrity_cr.yaml
+++ b/deploy/crds/4.2/file-integrity.openshift.io_v1alpha1_fileintegrity_cr.yaml
@@ -1,0 +1,7 @@
+apiVersion: file-integrity.openshift.io/v1alpha1
+kind: FileIntegrity
+metadata:
+  name: example-fileintegrity
+  namespace: openshift-file-integrity
+spec:
+  config: {}


### PR DESCRIPTION
@jhrozek @JAORMX  - Brought up in https://github.com/mrogers950/file-integrity-operator/pull/11#issuecomment-550015288 , let's keep the ability to install on <= 4.2 for now.