### PR TITLE
move first-run db init to init container

### DIFF
--- a/pkg/controller/fileintegrity/config_defaults.go
+++ b/pkg/controller/fileintegrity/config_defaults.go
@@ -1,6 +1,10 @@
 package fileintegrity
 
 var aideInitContainerScript = `#!/bin/sh
+    if test ! -f /hostroot/etc/kubernetes/aide.db.gz; then
+      echo "initializing AIDE db"
+      aide -c /tmp/aide.conf -i
+    fi
     if test -f /hostroot/etc/kubernetes/aide.reinit; then
       echo "reinitializing AIDE db"
       mv /hostroot/etc/kubernetes/aide.db.gz /hostroot/etc/kubernetes/aide.db.gz.backup-$(date +%s)
@@ -15,10 +19,6 @@ var aideReinitContainerScript = `#!/bin/sh
 `
 
 var aideScript = `#!/bin/sh
-    if test ! -f /hostroot/etc/kubernetes/aide.db.gz; then
-      echo "initializing AIDE db"
-      aide -c /tmp/aide.conf -i
-    fi
     while true; do
       echo "running AIDE check.."
       aide -c /tmp/aide.conf


### PR DESCRIPTION
This is so the daemonSet does not report ready status before the database is initialized.
@JAORMX @jhrozek 