### PR TITLE
Add end-to-end testing with opreator-sdk

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -1,0 +1,54 @@
+package e2e
+
+import (
+	goctx "context"
+	"testing"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fileintv1alpha1 "github.com/mrogers950/file-integrity-operator/pkg/apis/fileintegrity/v1alpha1"
+	"github.com/mrogers950/file-integrity-operator/pkg/common"
+)
+
+func TestFileIntegritySingleRun(t *testing.T) {
+	testctx := setupTestRequirements(t)
+	defer testctx.Cleanup()
+
+	namespace, err := testctx.GetNamespace()
+	if err != nil {
+		t.Errorf("could not get namespace: %v", err)
+	}
+	testctx.AddCleanupFn(cleanUp(t, namespace))
+
+	setupFileIntegrityOperatorCluster(t, testctx)
+	f := framework.Global
+
+	t.Log("Creating FileIntegrity object")
+	testIntegrityCheck := &fileintv1alpha1.FileIntegrity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-check",
+			Namespace: namespace,
+		},
+		Spec: fileintv1alpha1.FileIntegritySpec{
+			Config: fileintv1alpha1.FileIntegrityConfig{},
+		},
+	}
+	cleanupOptions := framework.CleanupOptions{
+		TestContext:   testctx,
+		Timeout:       cleanupTimeout,
+		RetryInterval: cleanupRetryInterval,
+	}
+	err = f.Client.Create(goctx.TODO(), testIntegrityCheck, &cleanupOptions)
+	if err != nil {
+		t.Errorf("could not create fileintegrity object: %v", err)
+	}
+
+	err = waitForDaemonSet(daemonSetIsReady(f.KubeClient, common.DaemonSetName, namespace))
+	if err != nil {
+		t.Error(err)
+	}
+	t.Log("ds OK")
+
+	// TODO: Check the status of the fileIntegrity object to see that we're doing alright!
+}

--- a/tests/e2e/helpers.go
+++ b/tests/e2e/helpers.go
@@ -1,0 +1,208 @@
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	kerr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/mrogers950/file-integrity-operator/pkg/apis"
+	fileintv1alpha1 "github.com/mrogers950/file-integrity-operator/pkg/apis/fileintegrity/v1alpha1"
+	"github.com/mrogers950/file-integrity-operator/pkg/common"
+)
+
+const (
+	pollInterval         = 2 * time.Second
+	timeout              = time.Second * 120
+	retryInterval        = time.Second * 5
+	cleanupRetryInterval = time.Second * 1
+	cleanupTimeout       = time.Second * 5
+)
+
+func cleanUp(t *testing.T, namespace string) func() error {
+	return func() error {
+		f := framework.Global
+
+		if _, err := f.KubeClient.AppsV1().DaemonSets(namespace).Create(cleanAideDaemonset(namespace)); err != nil {
+			return err
+		}
+
+		if err := waitForDaemonSet(daemonSetWasScheduled(f.KubeClient, "aide-clean", namespace)); err != nil {
+			return err
+		}
+
+		if err := f.KubeClient.AppsV1().DaemonSets(namespace).Delete("aide-clean", &metav1.DeleteOptions{}); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func setupTestRequirements(t *testing.T) *framework.TestCtx {
+	fileIntegrities := &fileintv1alpha1.FileIntegrityList{}
+	err := framework.AddToFrameworkScheme(apis.AddToScheme, fileIntegrities)
+	if err != nil {
+		t.Fatalf("TEST SETUP: failed to add custom resource scheme to framework: %v", err)
+	}
+	return framework.NewTestCtx(t)
+}
+func setupFileIntegrityOperatorCluster(t *testing.T, ctx *framework.TestCtx) {
+	cleanupOptions := framework.CleanupOptions{
+		TestContext:   ctx,
+		Timeout:       cleanupTimeout,
+		RetryInterval: cleanupRetryInterval,
+	}
+	err := ctx.InitializeClusterResources(&cleanupOptions)
+	if err != nil {
+		t.Fatalf("failed to initialize cluster resources: %v", err)
+	}
+	t.Log("Initialized cluster resources")
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// get global framework variables
+	f := framework.Global
+	// wait for file-integrity-operator to be ready
+	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "file-integrity-operator", 1, retryInterval, timeout)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+func daemonSetIsReady(c kubernetes.Interface, name, namespace string) wait.ConditionFunc {
+	return func() (bool, error) {
+		daemonSet, err := c.AppsV1().DaemonSets(namespace).Get(name, metav1.GetOptions{})
+		if err != nil && !kerr.IsNotFound(err) {
+			return false, err
+		}
+		if kerr.IsNotFound(err) {
+			return false, nil
+		}
+		if daemonSet.Status.DesiredNumberScheduled != daemonSet.Status.NumberAvailable {
+			return false, nil
+		}
+		return true, nil
+	}
+}
+
+func daemonSetWasScheduled(c kubernetes.Interface, name, namespace string) wait.ConditionFunc {
+	return func() (bool, error) {
+		daemonSet, err := c.AppsV1().DaemonSets(namespace).Get(name, metav1.GetOptions{})
+		if err != nil && !kerr.IsNotFound(err) {
+			return false, err
+		}
+		if kerr.IsNotFound(err) {
+			return false, nil
+		}
+		if daemonSet.Status.DesiredNumberScheduled != daemonSet.Status.CurrentNumberScheduled {
+			return false, nil
+		}
+		return true, nil
+	}
+}
+
+func podRunning(c kubernetes.Interface, podName, namespace string) wait.ConditionFunc {
+	return func() (bool, error) {
+		pod, err := c.CoreV1().Pods(namespace).Get(podName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		switch pod.Status.Phase {
+		case corev1.PodRunning:
+			return true, nil
+		case corev1.PodFailed, corev1.PodSucceeded:
+			return false, fmt.Errorf("pod ran to completion")
+		}
+		return false, nil
+	}
+}
+
+// Waits default amount of time (PodStartTimeout) for the specified pod to become running.
+// Returns an error if timeout occurs first, or pod goes in to failed state.
+func waitForPodRunningInNamespace(c kubernetes.Interface, pod *corev1.Pod) error {
+	if pod.Status.Phase == corev1.PodRunning {
+		return nil
+	}
+	return waitTimeoutForPodRunningInNamespace(c, pod.Name, pod.Namespace, timeout)
+}
+
+func waitTimeoutForPodRunningInNamespace(c kubernetes.Interface, podName, namespace string, timeout time.Duration) error {
+	return wait.PollImmediate(pollInterval, timeout, podRunning(c, podName, namespace))
+}
+
+func waitForDaemonSet(daemonSetCallback wait.ConditionFunc) error {
+	return wait.PollImmediate(pollInterval, timeout, daemonSetCallback)
+}
+
+// This daemonSet runs a command to clear the aide content from the host
+func cleanAideDaemonset(namespace string) *appsv1.DaemonSet {
+	priv := true
+	runAs := int64(0)
+
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aide-clean",
+			Namespace: namespace,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "aide-clean",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "aide-clean",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "node-role.kubernetes.io/master",
+							Operator: "Exists",
+							Effect:   "NoSchedule",
+						},
+					},
+					ServiceAccountName: common.OperatorServiceAccountName,
+					Containers: []corev1.Container{
+						{
+							SecurityContext: &corev1.SecurityContext{
+								Privileged: &priv,
+								RunAsUser:  &runAs,
+							},
+							Name:    "aide-clean",
+							Image:   "busybox",
+							Command: []string{"/bin/sh"},
+							Args:    []string{"-c", "rm -f /hostroot/etc/kubernetes/aide* || true"},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "hostroot",
+									MountPath: "/hostroot",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "hostroot",
+							VolumeSource: corev1.VolumeSource{
+								HostPath: &corev1.HostPathVolumeSource{
+									Path: "/",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -1,0 +1,11 @@
+package e2e
+
+import (
+	"testing"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+)
+
+func TestMain(m *testing.M) {
+	framework.MainEntry(m)
+}


### PR DESCRIPTION
This uses the operator-sdk test framework to add end-to-end testing.
It's enabled through the `e2e` make target.

Co-Authored-By: Matt Rogers <mrogers@redhat.com>